### PR TITLE
Wikipedia api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "jbuilder"
 # これを使うことで、環境ごとに異なる設定を簡単に管理できる
 gem "dotenv", groups: [ :development, :test ]
 
-gem "faraday"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "dotenv", groups: [ :development, :test ]
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
-
+gem "igdb"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "dotenv", groups: [ :development, :test ]
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
-gem "igdb"
+gem "wiki-api"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "jbuilder"
 # これを使うことで、環境ごとに異なる設定を簡単に管理できる
 gem "dotenv", groups: [ :development, :test ]
 
+gem "faraday"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,13 +102,22 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    declarative (0.0.20)
+    domain_name (0.6.20240107)
     dotenv (3.1.7)
     drb (2.2.1)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    igdb (0.7.0)
+      multi_json
+      representable
+      rest-client
     io-console (0.8.0)
     irb (1.14.3)
       rdoc (>= 4.0.0)
@@ -131,9 +140,14 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0107)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_json (1.15.0)
     net-imap (0.5.5)
       date
       net-protocol
@@ -143,6 +157,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -216,6 +231,15 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.4.0)
     rubocop (1.70.0)
       json (~> 2.3)
@@ -266,11 +290,13 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
+    trailblazer-option (0.1.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -307,6 +333,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv
+  igdb
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,12 @@ GEM
     dotenv (3.1.7)
     drb (2.2.1)
     erubi (1.13.1)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -134,6 +140,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.5)
       date
       net-protocol
@@ -274,6 +282,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     useragent (0.16.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -307,6 +316,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv
+  faraday
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,12 +105,6 @@ GEM
     dotenv (3.1.7)
     drb (2.2.1)
     erubi (1.13.1)
-    faraday (2.12.2)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -140,8 +134,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
-    net-http (0.6.0)
-      uri
     net-imap (0.5.5)
       date
       net-protocol
@@ -282,7 +274,6 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
     useragent (0.16.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -316,7 +307,6 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv
-  faraday
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,22 +102,13 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    declarative (0.0.20)
-    domain_name (0.6.20240107)
     dotenv (3.1.7)
     drb (2.2.1)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    http-accept (1.7.0)
-    http-cookie (1.0.8)
-      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    igdb (0.7.0)
-      multi_json
-      representable
-      rest-client
     io-console (0.8.0)
     irb (1.14.3)
       rdoc (>= 4.0.0)
@@ -140,14 +131,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    mime-types (3.6.0)
-      logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
-    multi_json (1.15.0)
     net-imap (0.5.5)
       date
       net-protocol
@@ -157,7 +143,6 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -231,15 +216,6 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.4.0)
     rubocop (1.70.0)
       json (~> 2.3)
@@ -290,13 +266,11 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
-    trailblazer-option (0.1.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uber (0.1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -311,6 +285,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wiki-api (0.1.2)
+      nokogiri (> 1.13.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -333,7 +309,6 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv
-  igdb
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
@@ -346,6 +321,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  wiki-api
 
 BUNDLED WITH
    2.5.18


### PR DESCRIPTION
# gem wiki-apiとは
wiki-apiというgemを使うと、WikipediaのAPIを簡単に呼び出して情報を取得したり、操作したりできる
特に、リクエストの書き方がシンプルになるから、手間が減る効果がある

# gemfileにgem wiki-apiを記述する
gemfileに追記し、bundle installで実行する
````Ruby
gem 'wiki-api'
````