### PR TITLE
同じ日付の複数の記念日がある場合、ランダムに1つを選ぶ

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,13 +6,13 @@ class User < ApplicationRecord
 
   def find_closest_national_day
     birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
-  
+
     # ±3日以内の記念日を取得
     closest_days = NationalDay.all.select do |day|
       national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
       (birth_month_day - national_day_month_day).abs <= 3
     end
-  
+
     closest_days.sample # ランダムに1つ選ぶ
-  end  
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,13 @@ class User < ApplicationRecord
 
   def find_closest_national_day
     birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
-    days = NationalDay.all.sort_by do |day|
+  
+    # ±3日以内の記念日を取得
+    closest_days = NationalDay.all.select do |day|
       national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
-      (birth_month_day - national_day_month_day).abs
+      (birth_month_day - national_day_month_day).abs <= 3
     end
-
-    days.find do |day|
-      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
-      (birth_month_day - national_day_month_day).abs <= 7
-    end
-  end
+  
+    closest_days.sample # ランダムに1つ選ぶ
+  end  
 end


### PR DESCRIPTION
# 理由
Rake タスクを修正し、画面出せることは確認できたが、CSV のデータで日付がかぶっているものは( )のようになる
(ex:10月1日はキプロスの独立記念日、中国の国慶節が被っているが、最初のインポートが優先されてキプロスしか出なくなる)
ランダムで1つ出せるようにしたらいいと考え、修正を決断
また7日以内より+-3日程度が好ましいと考えてこちらも修正

# 1. find_closest_national_day を修正
現在の find_closest_national_day メソッドでは、最初に見つかった1つだけを返しているので、これをランダムに1つ選ぶように変更する
Before
``````ruby
def find_closest_national_day
    birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
    days = NationalDay.all.sort_by do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs
    end

    days.find do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 7
    end
  end
``````
After
``````ruby
def find_closest_national_day
    birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定

    # ±3日以内の記念日を取得
    closest_days = NationalDay.all.select do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day) # birth_month_day を "MM-DD" 形式に変換し、同じ日付の記念日をすべて取得
      (birth_month_day - national_day_month_day).abs <= 3 # もし同じ日付の記念日がなければ、±3日以内の記念日を取得し、その中からランダムで1つ選択
    end

    closest_days.sample # もし1つ以上の記念日があれば、sample でランダムに1つ選択
  end 
``````



