### PR TITLE
googleアナリティクスの導入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,17 @@
 <html>
   <head>
     <title><%= content_for(:title) || "BirthNation" %></title>
+    <% if Rails.env.production? %>
+      <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6P48KF29W9"></script>
+    <script>
+     window.dataLayer = window.dataLayer || [];
+     function gtag(){dataLayer.push(arguments);}
+     gtag('js', new Date());
+
+     gtag('config', 'G-6P48KF29W9');
+    </script>
+    <% end %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
# 理由
個人的に導入してみたかったから

# タグをRailsアプリ内に組み込む

renderメソッドを使ってlayoutファイルへ貼り付け
「_google_analytics.html.erb」をlayouts配下へ新規作成
app/views/layouts/_google_analytics.html.erb
```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=私の測定ID"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', '私の測定ID');
</script>
```

# 参考
https://zenn.dev/yoiyoicho/articles/1fe05797a1bbc4