### PR TITLE
ブラウザの制限解除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
 
   add_flash_types :success, :danger
   # add_flash_types とは、

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-
   add_flash_types :success, :danger
   # add_flash_types とは、
   # フラッシュメッセージのタイプを追加するメソッド


### PR DESCRIPTION
# 理由
## 機能制限の回避: 
最新の機能や技術に依存しないアプリケーションを作成したい場合、特定のブラウザ要件を外すことで、機能制限から解放されるから

## ユーザー体験の向上: 
一部のユーザーが古いブラウザを使用している場合、アクセスできないことで不便を感じることがあるため、これを解消するため