### PR TITLE
バグ修正(一時修正でランダム表示を取りやめることにした)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,11 +8,9 @@ class User < ApplicationRecord
     birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
 
     # ±3日以内の記念日を取得
-    closest_days = NationalDay.all.select do |day|
+    closest_days = NationalDay.all.find do |day|
       national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
       (birth_month_day - national_day_month_day).abs <= 3
     end
-
-    closest_days.sample # ランダムに1つ選ぶ
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,11 @@ class User < ApplicationRecord
     birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
 
     # ±3日以内の記念日を取得
-    closest_days = NationalDay.all.find do |day|
+    closest_days = NationalDay.all.select do |day|
       national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
       (birth_month_day - national_day_month_day).abs <= 3
     end
+    # 記念日との日数差が最も小さいものを選択
+    closest_days.min_by { |day| (birth_month_day - Date.new(2000, day.national_day.month, day.national_day.day)).abs }
   end
 end

--- a/db/national_days.csv
+++ b/db/national_days.csv
@@ -150,7 +150,7 @@ country_name,national_day,description,remark,image_url
 韓国,10-03,開天節,檀君神話に基づく、建国を記念し、天に感謝する日,https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/320px-Flag_of_South_Korea.svg.png
 ドイツ,10-03,ドイツ統一の日,1990年10月3日にドイツが再統一したことを記念するドイツ連邦共和国の建国記念日,https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Germany.svg/320px-Flag_of_Germany.svg.png
 レソト,10-04,独立記念日,無し,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Flag_of_Lesotho.svg/320px-Flag_of_Lesotho.svg.png
-ウガンダ,10-09,独立記念日,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Flag_of_Uganda.svg/320px-Flag_of_Uganda.svg.png
+ウガンダ,10-09,独立記念日,無し,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Flag_of_Uganda.svg/320px-Flag_of_Uganda.svg.png
 中華民国(台湾),10-10,中華民国国慶日（双十節）,辛亥革命の発端となった武昌起義を記念する日,https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Flag_of_the_Republic_of_China.svg/320px-Flag_of_the_Republic_of_China.svg.png
 スペイン,10-12,イスパニアの日,無し,https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Flag_of_Spain.svg/320px-Flag_of_Spain.svg.png
 赤道ギニア,10-12,独立記念日,無し,https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Flag_of_Equatorial_Guinea.svg/320px-Flag_of_Equatorial_Guinea.svg.png


### PR DESCRIPTION
# バグ内容
記念日が複数ある場合でもランダムで1つ表示される影響で、動的OGPの結果とリンクと文面が異なる
[![Image from Gyazo](https://i.gyazo.com/e6864e25437deea61e4773025d9468ae.png)](https://gyazo.com/e6864e25437deea61e4773025d9468ae)

# 修正方法1
一時修正でランダム表示を取りやめる
Before
```ruby
 # ±3日以内の記念日を取得
    closest_days = NationalDay.all.select do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 3
    end

    closest_days.sample # ランダムに1つ選ぶ
  end
```
After
```ruby
 # ±3日以内の記念日を取得
    closest_days = NationalDay.all.find do |day| # .select を使って、条件に合うすべての記念日を取得していたので、findにして、固定させる
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 3
    end
  # closest_days.sampleを削除し、ランダムに1つ選ぶのをやめる
  end
```
## それでもランダムで表示させたい場合、
# 修正方法2
OGPとシェア機能で同じ記念日を表示させるために、ランダムではなく 常に同じ1つの記念日を取得する方法 を適用してみる

Before
```ruby
 # ±3日以内の記念日を取得
    closest_days = NationalDay.all.select do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 3
    end

    closest_days.sample # ランダムに1つ選ぶ
  end
```
After
```ruby
 # ±3日以内の記念日を取得
    closest_days = NationalDay.all.select do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 3
    end

    # 記念日との日数差が最も小さいものを選択
    closest_days.min_by { |day| (birth_month_day - Date.new(2000, day.national_day.month, day.national_day.day)).abs }
  end
```