### PR TITLE
Change the way to get db to data

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
 
   def result
     @user = User.find(params[:id])
-    @national_day = @user.find_closest_national_day  # DB から記念日を取得
+    @national_day = @user.find_closest_national_day
 
     # OGP画像のテキスト（国名 + 記念日の日付）
     ogp_text = @national_day.present? ? "#{@national_day.country_name}\n#{@national_day.description}" : "該当なし"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,14 +12,14 @@ class UsersController < ApplicationController
 
   def result
     @user = User.find(params[:id])
-    @national_day = @user.find_closest_national_day
-
+    @national_day = @user.find_closest_national_day  # DB から記念日を取得
+  
     # OGP画像のテキスト（国名 + 記念日の日付）
     ogp_text = @national_day.present? ? "#{@national_day.country_name}\n#{@national_day.description}" : "該当なし"
-
+  
     # 動的OGP画像のURL
     ogp_image = @national_day.present? ? ogp_image_url(ogp_text) : default_ogp_image_url
-
+  
     # metaタグの設定
     set_meta_tags(
       title: "#{@user.name}さんの誕生日に近い国の誕生日",
@@ -39,6 +39,7 @@ class UsersController < ApplicationController
       }
     )
   end
+  
 
   private
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,13 +13,13 @@ class UsersController < ApplicationController
   def result
     @user = User.find(params[:id])
     @national_day = @user.find_closest_national_day  # DB から記念日を取得
-  
+
     # OGP画像のテキスト（国名 + 記念日の日付）
     ogp_text = @national_day.present? ? "#{@national_day.country_name}\n#{@national_day.description}" : "該当なし"
-  
+
     # 動的OGP画像のURL
     ogp_image = @national_day.present? ? ogp_image_url(ogp_text) : default_ogp_image_url
-  
+
     # metaタグの設定
     set_meta_tags(
       title: "#{@user.name}さんの誕生日に近い国の誕生日",
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
       }
     )
   end
-  
+
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,14 +5,12 @@ class User < ApplicationRecord
   validates :birth_day, inclusion: { in: 1..31 }
 
   def find_closest_national_day
-    birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定
+    birth_month_day = Date.new(2000, birth_month, birth_day)
 
-    # ±3日以内の記念日を取得
-    closest_days = NationalDay.all.select do |day|
-      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
-      (birth_month_day - national_day_month_day).abs <= 3
-    end
-    # 記念日との日数差が最も小さいものを選択
-    closest_days.min_by { |day| (birth_month_day - Date.new(2000, day.national_day.month, day.national_day.day)).abs }
+    NationalDay
+      # ±3日以内の記念日をDBにて取得
+      .where("ABS(EXTRACT(DOY FROM national_day) - EXTRACT(DOY FROM CAST(? AS DATE))) <= 3", birth_month_day)
+      .order(Arel.sql("ABS(EXTRACT(DOY FROM national_day) - EXTRACT(DOY FROM CAST('#{birth_month_day}' AS DATE))) ASC"))
+      .first
   end
 end

--- a/lib/tasks/import_national_days.rake
+++ b/lib/tasks/import_national_days.rake
@@ -3,7 +3,7 @@ namespace :import do
     task national_days: :environment do
       require "csv"
 
-      file_path = Rails.root.join('db/national_days.csv') # CSVのパス
+      file_path = Rails.root.join("db/national_days.csv") # CSVのパス
       puts "Importing national days from #{file_path}..."
       CSV.foreach(file_path, headers: true) do |row|
         NationalDay.create!(

--- a/lib/tasks/import_national_days.rake
+++ b/lib/tasks/import_national_days.rake
@@ -3,7 +3,8 @@ namespace :import do
     task national_days: :environment do
       require "csv"
 
-      file_path = Rails.root.join("db", "national_days.csv")
+      file_path = Rails.root.join('db/national_days.csv') # CSVのパス
+      puts "Importing national days from #{file_path}..."
       CSV.foreach(file_path, headers: true) do |row|
         NationalDay.create!(
           country_name: row["country_name"],


### PR DESCRIPTION
# 概要
MVPリリース後にSierの知人からのコメントにて
「毎回csvから取得するより、記念日をdbで突っ込んでorderbyでとってきたほうが良いのではないか」と回答いただいた

# 理由
**CSVからデータを取得するのをやめるという意味ではなく**、CSVデータを使って初めてデータベースにインポートし、その後はデータベースを使って記念日を管理するという意味合いになる
具体的には、最初にCSVからデータをインポートしてデータベースに保存した後、必要な時にはデータベースから直接データを取得する。これにより、データの取得が速くなり、整合性も保たれる
(※csvデータ作らないでコンソール上にデータを突っ込むという意味合いかとはき違えていた)

# 方法
## 1:CSVデータをDBに一括インポートする Rakeタスクに修正する
lib/tasks/import_national_days.rakeにてCSVデータをDBに一括インポートするよう修正する
Before
````Ruby
file_path = Rails.root.join("db", "national_days.csv")
````
After
````Ruby
file_path = Rails.root.join("db/national_days.csv") # CSVのパス
puts "Importing national days from #{file_path}..."
````
## 2:bash環境にてインポート実行する
````bash
rake import:national_days
````
## 3:find_closest_national_day をDBクエリに変更
ユーザー側のモデルに手CSVから探していた find_closest_national_day メソッドを、DBを使って検索する形に変更
app/models/user.rb
Before
````Ruby
def find_closest_national_day
    birth_month_day = Date.new(2000, birth_month, birth_day) # 基準年を2000年に固定

    # ±3日以内の記念日を取得
    closest_days = NationalDay.all.select do |day|
      national_day_month_day = Date.new(2000, day.national_day.month, day.national_day.day)
      (birth_month_day - national_day_month_day).abs <= 3
    end
    # 記念日との日数差が最も小さいものを選択
    closest_days.min_by { |day| (birth_month_day - Date.new(2000, day.national_day.month, day.national_day.day)).abs }
 end
````
After
````Ruby
def find_closest_national_day
    birth_month_day = Date.new(2000, birth_month, birth_day)

    NationalDay
      .where("ABS(EXTRACT(DOY FROM national_day) - EXTRACT(DOY FROM CAST(? AS DATE))) <= 3", birth_month_day) 
# where で±3日以内のデータを取得
      .order(Arel.sql("ABS(EXTRACT(DOY FROM national_day) - EXTRACT(DOY FROM CAST('#{birth_month_day}' AS DATE))) ASC")) 
# order で最も近い日を取得(DB内のデータのみを対象にする)
      .first
  end
````
# DBでインポートする方法に変える効果
### パフォーマンスの向上
毎回CSVからデータを取得するのは、特にデータが増えてくるとパフォーマンスに影響を与える可能性がある
データベースを使用すれば、インデックスを活用して高速にデータを取得できるから、効率が良くなる

### データ整合性の確保
データベースを使うことで、データの整合性を保つことができる
CSVファイルだと、手動での更新ミスやフォーマットの不一致が起こりやすいけど、データベースでは制約を設けることができるから、より信頼性が高い

### データの操作が容易
データベースを使用すれば、CRUD（Create, Read, Update, Delete）操作が簡単に行える
新しい記念日を追加したり、既存の情報を更新したりするのもスムーズになる
CSVだと、手動での編集や再インポートが必要になることが多いから、手間がかかる

### クエリの柔軟性
SQLを使えば、複雑な条件でデータを取得したり、複数のテーブルを結合して情報を取得したりすることができる
CSVだと、こうした柔軟なデータ操作が困難になる

以上の理由から、記念日データはデータベースで管理し、必要に応じてCSVからインポートする仕組みを持つのが理想的